### PR TITLE
:bug: バッファタイプを判定してからcdするように修正 #5

### DIFF
--- a/vim/conf.d/etc.vim
+++ b/vim/conf.d/etc.vim
@@ -7,10 +7,19 @@
 " に分類できないか、あるいはここの雑多な設定をまとめて別ファイルに吐き出せないか
 " 県とすること。
 
+" ターミナル以外を開いたときだけcdする
+function! s:change_dir()
+  if &l:buftype ==# 'terminal' || &l:buftype ==# 'nowrite'
+    return
+  endif
+
+  lcd %:p:h
+endfunction
+
 " 開いたファイルをカレントディレクトリに設定
 augroup grlcd
   autocmd!
-  autocmd BufEnter * lcd %:p:h
+  autocmd BufEnter *.* call s:change_dir()
 augroup END
 
 set nobomb      " BOMなしで保存する


### PR DESCRIPTION
autocmdではイベント時に特定の処理を呼び出す登録をする。

今まではバッファ移動時にcdする処理を呼び出していたが、
temrinalとfilterを開いたときは、その処理を呼んでほしくない。

buftypeでタイプを判定して、実行しないように修正することで
エラーが発生しないようにした。